### PR TITLE
Add emulation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ An example `<config-file>` is `conf.yaml`.
 host:
   name: localhost
   port: 3000
+  is-emulate: false
 topology:
   stable-core-count: 3
   dynamic-core-count: 1

--- a/internal/configs/parser.go
+++ b/internal/configs/parser.go
@@ -17,8 +17,9 @@ func NewConfigs(path string) *model.ConfYaml {
 	loadConfigs(path, k)
 	return &model.ConfYaml{
 		Host: model.Host{
-			Name: k.String("host.name"),
-			Port: k.Int("host.port"),
+			Name:      k.String("host.name"),
+			Port:      k.Int("host.port"),
+			IsEmulate: k.Bool("host.is-emulate"),
 		},
 		Topology: model.Topology{
 			StableCoreCount:  k.Int("topology.stable-core-count"),

--- a/internal/dummy/data.go
+++ b/internal/dummy/data.go
@@ -7,8 +7,9 @@ import (
 
 var DefaultConfigsBytes, _ = yaml.Marshal(&model.ConfYaml{
 	Host: model.Host{
-		Name: "localhost",
-		Port: 3000,
+		Name:      "localhost",
+		Port:      3000,
+		IsEmulate: false,
 	},
 	Topology: model.Topology{
 		StableCoreCount:  4,

--- a/internal/model/obj.go
+++ b/internal/model/obj.go
@@ -15,8 +15,9 @@ type SleepInfo struct {
 }
 
 type Host struct {
-	Name string `yaml:"name"`
-	Port int    `yaml:"port"`
+	Name      string `yaml:"name"`
+	Port      int    `yaml:"port"`
+	IsEmulate bool   `yaml:"is-emulate"`
 }
 
 type Topology struct {

--- a/internal/power/api.go
+++ b/internal/power/api.go
@@ -7,6 +7,11 @@ import (
 
 func (o *SleepController) Info() map[string]string {
 	fmt.Println("Listing out available sleep states...")
+	if o.isEmulate {
+		return map[string]string{
+			"message": "Controller is in emulation mode. All api responses are replied with the happy path response",
+		}
+	}
 	log.Printf("avl sleep states: %v\n", o.Host.AvailableCStates())
 	return map[string]string{
 		"avl-idle-states":  fmt.Sprintf("%v", o.Host.AvailableCStates()),
@@ -18,6 +23,10 @@ func (o *SleepController) Info() map[string]string {
 }
 
 func (o *SleepController) Sleep() error {
+	if o.isEmulate {
+		return nil
+	}
+
 	(*o).mu.Lock()
 	defer (*o).mu.Unlock()
 
@@ -35,6 +44,10 @@ func (o *SleepController) Sleep() error {
 }
 
 func (o *SleepController) Wake() error {
+	if o.isEmulate {
+		return nil
+	}
+
 	(*o).mu.Lock()
 	defer (*o).mu.Unlock()
 
@@ -52,6 +65,10 @@ func (o *SleepController) Wake() error {
 }
 
 func (o *SleepController) OpFrequency(fMhz uint) error {
+	if o.isEmulate {
+		return nil
+	}
+
 	(*o).mu.Lock()
 	defer (*o).mu.Unlock()
 


### PR DESCRIPTION
Fixes #11.

Read a config through the conf yaml. If true, sleep controller responds with success for all apis. Further, info endpoint will tell that service is in emulation mode.